### PR TITLE
Event number fix

### DIFF
--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -12,4 +12,5 @@ export type Issue = {
   stack: string;
   level: IssueLevel;
   numEvents: number;
+  numUsers: number;
 };

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -45,6 +45,7 @@ describe("Issue List", () => {
           cy.wrap($el).contains(issue.name);
           cy.wrap($el).contains(issue.message);
           cy.wrap($el).contains(issue.numEvents);
+          cy.wrap($el).contains(issue.numUsers);
           cy.wrap($el).contains(firstLineOfStackTrace);
         });
     });

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -17,7 +17,8 @@ const levelColors = {
 };
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
-  const { name, message, stack, level, numEvents } = issue;
+  const { name, message, stack, level, numEvents, numUsers } = issue;
+  console.log(issue);
   const firstLineOfStackTrace = stack.split("\n")[1];
 
   return (
@@ -43,7 +44,7 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
         </Badge>
       </td>
       <td className={styles.cell}>{numEvents}</td>
-      <td className={styles.cell}>{numEvents}</td>
+      <td className={styles.cell}>{numUsers}</td>
     </tr>
   );
 }

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -18,7 +18,6 @@ const levelColors = {
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
   const { name, message, stack, level, numEvents, numUsers } = issue;
-  console.log(issue);
   const firstLineOfStackTrace = stack.split("\n")[1];
 
   return (


### PR DESCRIPTION
Ensure that the number of events and users is correctly displayed on the Issues page. Previously, the number of users was incorrect.